### PR TITLE
Use the Hex entity mode for Mac key generation; update docs a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We think it's pretty cool.
 1. get [Rust](https://www.rust-lang.org/learn/get-started)
 1. clone this repo: `git clone https://github.com/divvun/kbdgen.git`
 2. `cd kbdgen`
-1. `cargo install --path .`
+1. `cargo install --path .` (this installs `kbdgen` to the path)
 
 **Alternatively** - download a precompiled binary from nightly builds:
 
@@ -31,6 +31,10 @@ We think it's pretty cool.
 * [Windows](https://pahkat.uit.no/devtools/download/kbdgen?channel=nightly&platform=windows) (i686)
 
 Extract the archive, and move the binary to somewhere on your `$PATH`.
+
+## Example Usage
+
+`cargo run -- target --bundle-path C:\Projects\Divvun\keyboards\keyboard-sme\sme.kbdgen --output-path C:\KbdgenBuilds\sme_mac macos generate`
 
 ## License
 

--- a/docs/user/cli.adoc
+++ b/docs/user/cli.adoc
@@ -5,7 +5,7 @@ among the various linguistic targets: Windows, MacOS, .svg, etc.
 
 Example usage:
 
-`cargo run -- target ~/Projects/keyboard-sme/sme.kbdgen ~/KbdgenBuilds/SME windows`
+`cargo run -- target --bundle-path C:\Projects\Divvun\keyboards\keyboard-sme\sme.kbdgen --output-path C:\KbdgenBuilds\sme_mac macos generate`
 
 The first argument is the location of the given .kbdgen bundle (see below for 
 information on bundles) that the keyboard should be built from.

--- a/src/build/macos/macos_bundle.rs
+++ b/src/build/macos/macos_bundle.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use indexmap::IndexMap;
 use language_tags::LanguageTag;
 use serde::{Deserialize, Serialize};
-use xmlem::Document;
+use xmlem::{Document, display::Config, display::EntityMode};
 
 const TOP_FOLDER: &str = "Contents";
 const RESOURCES_FOLDER: &str = "Resources";
@@ -113,9 +113,12 @@ impl MacOsBundle {
                 });
         }
 
+        let mut config: Config = Config::default_pretty();
+        config.entity_mode = EntityMode::Hex;
+
         self.macos_layouts.insert(
             language_tag,
-            (name.to_string(), kbd_layout_doc.to_string_pretty()),
+            (name.to_string(), kbd_layout_doc.to_string_pretty_with_config(&config)),
         );
     }
 


### PR DESCRIPTION
Should address the issue in #10 