### PR TITLE
Add contact email to keyboard Info.plist

### DIFF
--- a/src/build/ios/generate_xcode.rs
+++ b/src/build/ios/generate_xcode.rs
@@ -13,12 +13,10 @@ use rayon::prelude::*;
 
 use crate::{
     build::{
-        ios::xcode_structures::*,
-        ios::{pbxproj::Pbxproj, IosProjectExt},
+        ios::{pbxproj::Pbxproj, xcode_structures::*, IosProjectExt},
         BuildStep,
     },
-    bundle::layout::IOsTarget,
-    bundle::KbdgenBundle,
+    bundle::{layout::IOsTarget, project::Project, KbdgenBundle},
 };
 
 const REPOSITORY: &str = "repo";
@@ -52,6 +50,7 @@ pub fn replace_all_occurances(input: String, character: char, replace_with: char
 pub fn generate_keyboard_plist(
     template_path: &Path,
     target: &IOsTarget,
+    project: &Project,
     value: &IosKeyboardSettings,
     display_name: &str,
     keyboard_index: usize,
@@ -73,6 +72,9 @@ pub fn generate_keyboard_plist(
         keyboard_plist.divvun_speller_package_key = None;
         keyboard_plist.divvun_speller_path = None;
     }
+
+    keyboard_plist.divvun_contact_email = project.email.clone();
+    tracing::debug!("Email: {}", project.email.clone());
 
     // keyboard_plist
     keyboard_plist.cf_bundle_display_name = display_name.to_string();
@@ -135,6 +137,8 @@ pub fn path_to_relative(path: &Path, relative_to: &str) -> PathBuf {
 }
 
 pub fn generate_icons(bundle: &KbdgenBundle, path: &Path) {
+    let key = LanguageTag::from_str("png").unwrap();
+    print!("{}", key);
     let icon = bundle
         .resources
         .ios
@@ -286,6 +290,7 @@ impl BuildStep for GenerateXcode {
                     generate_keyboard_plist(
                         &keyboard_plist_template,
                         layout.i_os.as_ref().unwrap(),
+                        &bundle.project,
                         &ios_keyboard_settings,
                         &default_display_name,
                         layout_index,

--- a/src/build/ios/generate_xcode.rs
+++ b/src/build/ios/generate_xcode.rs
@@ -136,8 +136,6 @@ pub fn path_to_relative(path: &Path, relative_to: &str) -> PathBuf {
 }
 
 pub fn generate_icons(bundle: &KbdgenBundle, path: &Path) {
-    let key = LanguageTag::from_str("png").unwrap();
-    print!("{}", key);
     let icon = bundle
         .resources
         .ios

--- a/src/build/ios/generate_xcode.rs
+++ b/src/build/ios/generate_xcode.rs
@@ -50,7 +50,7 @@ pub fn replace_all_occurances(input: String, character: char, replace_with: char
 pub fn generate_keyboard_plist(
     template_path: &Path,
     target: &IOsTarget,
-    project: &Project,
+    contact_email: &str,
     value: &IosKeyboardSettings,
     display_name: &str,
     keyboard_index: usize,
@@ -73,8 +73,7 @@ pub fn generate_keyboard_plist(
         keyboard_plist.divvun_speller_path = None;
     }
 
-    keyboard_plist.divvun_contact_email = project.email.clone();
-    tracing::debug!("Email: {}", project.email.clone());
+    keyboard_plist.divvun_contact_email = contact_email.to_string();
 
     // keyboard_plist
     keyboard_plist.cf_bundle_display_name = display_name.to_string();
@@ -290,7 +289,7 @@ impl BuildStep for GenerateXcode {
                     generate_keyboard_plist(
                         &keyboard_plist_template,
                         layout.i_os.as_ref().unwrap(),
-                        &bundle.project,
+                        &bundle.project.email,
                         &ios_keyboard_settings,
                         &default_display_name,
                         layout_index,

--- a/src/build/ios/xcode_structures.rs
+++ b/src/build/ios/xcode_structures.rs
@@ -49,6 +49,8 @@ pub struct KeyboardInfoPlist {
     pub divvun_speller_path: Option<String>,
     #[serde(rename = "DivvunSpellerPackageKey")]
     pub divvun_speller_package_key: Option<String>,
+    #[serde(rename = "DivvunContactEmail")]
+    pub divvun_contact_email: String,
     #[serde(rename = "CFBundleDevelopmentRegion")]
     pub cf_bundle_development_region: String,
     #[serde(rename = "CFBundleDisplayName")]


### PR DESCRIPTION
So that iOS can support a unique contact email per keyboard layout.