### PR TITLE
Use keyboard project.yaml metadata for generating plists

### DIFF
--- a/src/build/ios/generate_xcode.rs
+++ b/src/build/ios/generate_xcode.rs
@@ -282,12 +282,15 @@ impl BuildStep for GenerateXcode {
 
                     std::fs::create_dir_all(&current_layout_path).unwrap();
 
+                    let layout_project_path = bundle.path.join("projects").join(&format!("{}.yaml", layout_folder_name));
+                    let current_layout_project = serde_yaml::from_str::<Project>(&std::fs::read_to_string(&layout_project_path).unwrap()).unwrap();
+
                     // KEYBOARD PLIST
                     let layout_info_plist_path = current_layout_path.join(INFO_PLIST);
                     generate_keyboard_plist(
                         &keyboard_plist_template,
                         layout.i_os.as_ref().unwrap(),
-                        &bundle.project.email,
+                        &current_layout_project.email,
                         &ios_keyboard_settings,
                         &default_display_name,
                         layout_index,

--- a/src/bundle/fetch.rs
+++ b/src/bundle/fetch.rs
@@ -6,6 +6,9 @@ pub async fn fetch(target: &Path, project: &Project) -> anyhow::Result<()> {
     tracing::debug!("Create layouts dir");
     std::fs::create_dir_all(target.join("layouts"))?;
 
+    tracing::debug!("Create projects dir");
+    std::fs::create_dir_all(target.join("projects"))?;
+
     for (id, bundle) in project.dependencies.iter() {
         tracing::debug!("id: {}, bundle: {:?}", &id, &bundle);
         let branch = bundle.branch.as_deref().unwrap_or_else(|| "main".into());
@@ -39,6 +42,11 @@ pub async fn fetch(target: &Path, project: &Project) -> anyhow::Result<()> {
                 to_path.display()
             );
             std::fs::copy(from_path, to_path)?;
+
+            let project_from_path = kbdgen_path.join("project.yaml");
+            let project_to_path = target.join("projects").join(format!("{}.yaml", layout));
+            tracing::info!("Copying {} to {}...", project_from_path.display(), project_to_path.display());
+            std::fs::copy(project_from_path, project_to_path)?;
         }
     }
 


### PR DESCRIPTION
Allows using metadata provided in a keyboard's `project.yaml` when generating a corresponding `Info.plist`. For now this is being used to get the contact email for a given keyboard.

Steps are:
1. Download the `project.yaml` for each dependency during the `kbdgen fetch` step
2. When generating Xcode project, read the newly saved `<keyboard-layout>.yaml`
3. Extract email address and write to `Info.plist`

This is currently being used in cases where an iPad layout is not yet supported. The email in the lang's `.kbdgen/project.yaml` will be used when someone wants to request support.